### PR TITLE
Ajouter de la validation pour la method CalculerMoyenne

### DIFF
--- a/OperationsMathematiques.cs
+++ b/OperationsMathematiques.cs
@@ -9,6 +9,10 @@ namespace H23_Dev_Info_Examen2
     {
         public static double CalculerMoyenne(List<int> valeurs)
         {
+            if (valeurs == null || valeurs.Count == 0)
+            {
+                return -1;
+            }
             double moyenne = valeurs.Average();
             return moyenne;                                          
         }

--- a/Program.cs
+++ b/Program.cs
@@ -10,7 +10,14 @@ namespace H23_Dev_Info_Examen2
         {
             var liste = new List<int>();
             var moyenne = OperationsMathematiques.CalculerMoyenne(liste);
-            Console.WriteLine(moyenne);
+            if (moyenne == -1)
+            {
+                Console.WriteLine("Donner invalides");
+            }
+            else
+            {
+                Console.WriteLine(moyenne);
+            }
         }
     }
 }


### PR DESCRIPTION
Modifiez la méthode « CalculerMoyenne » afin qu’elle retourne « -1 » si la liste passée en paramètre d’entrée est null ou vide.
Modifiez la méthode « Main » afin qu’elle affiche le message « données invalides » si la moyenne retournée est égale à -1.